### PR TITLE
Qt6: Add support for Qt6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macOS-latest, ubuntu-latest]
-        version: ['5.15.2']
+        version: ['5.15.2', '6.1.0']
     steps:
       - uses: actions/checkout@v2
 

--- a/include/QOlm/QOlmBase.hpp
+++ b/include/QOlm/QOlmBase.hpp
@@ -209,11 +209,16 @@ protected:
     virtual void removeLastChild() = 0;
 
 private:
+#if QT_VERSION_MAJOR < 6
+    using qolm_size_type = int;
+#else
+    using qolm_size_type = qsizetype;
+#endif
     static void appendDefaultChild(QQmlListProperty<QObject>* list, QObject* child);
-    static int defaultChildrenCount(QQmlListProperty<QObject>* list);
-    static QObject* defaultChild(QQmlListProperty<QObject>* list, int index);
+    static qolm_size_type defaultChildrenCount(QQmlListProperty<QObject>* list);
+    static QObject* defaultChild(QQmlListProperty<QObject>* list, qolm_size_type index);
     static void clearDefaultChildren(QQmlListProperty<QObject>* list);
-    static void replaceDefaultChild(QQmlListProperty<QObject>* list, int index, QObject* child);
+    static void replaceDefaultChild(QQmlListProperty<QObject>* list, qolm_size_type index, QObject* child);
     static void removeLastChild(QQmlListProperty<QObject>* list);
 };
 

--- a/src/QOlmBase.cpp
+++ b/src/QOlmBase.cpp
@@ -43,12 +43,12 @@ void QOlmBase::appendDefaultChild(QQmlListProperty<QObject>* list, QObject* chil
     return reinterpret_cast<QOlmBase*>(list->data)->appendDefaultChild(child);
 }
 
-int QOlmBase::defaultChildrenCount(QQmlListProperty<QObject>* list)
+QOlmBase::qolm_size_type QOlmBase::defaultChildrenCount(QQmlListProperty<QObject>* list)
 {
     return reinterpret_cast<QOlmBase*>(list->data)->defaultChildrenCount();
 }
 
-QObject* QOlmBase::defaultChild(QQmlListProperty<QObject>* list, int index)
+QObject* QOlmBase::defaultChild(QQmlListProperty<QObject>* list, qolm_size_type index)
 {
     return reinterpret_cast<QOlmBase*>(list->data)->defaultChild(index);
 }
@@ -58,7 +58,7 @@ void QOlmBase::clearDefaultChildren(QQmlListProperty<QObject>* list)
     return reinterpret_cast<QOlmBase*>(list->data)->clearDefaultChildren();
 }
 
-void QOlmBase::replaceDefaultChild(QQmlListProperty<QObject>* list, int index, QObject* child)
+void QOlmBase::replaceDefaultChild(QQmlListProperty<QObject>* list, qolm_size_type index, QObject* child)
 {
     return reinterpret_cast<QOlmBase*>(list->data)->replaceDefaultChild(index, child);
 }


### PR DESCRIPTION
I was trying to port Qaterial to Qt6 and found this issue.

function signatures listed below are changed (class `QQmlListProperty`)

```c++
    CountFunction = qsizetype (*)(QQmlListProperty<T> *);
    AtFunction = T *(*)(QQmlListProperty<T> *, qsizetype);
    ReplaceFunction = void (*)(QQmlListProperty<T> *, qsizetype, T *);
```
  where `int` is replaced by `qsizetype`.

  In this PR a conditional type alias is used to keep the compatibility for both Qt5 and 6.

2. Added new matrix item for GitHub Actions.