### PR TITLE
🔨 Only look for qt if not `Qt::Core` target exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,8 +119,10 @@ endif()
 
 # ───── DEPENDENCIES ─────
 
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Qml REQUIRED)
+if(NOT TARGET Qt::Core)
+  find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+  find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Qml REQUIRED)
+endif()
 
 # ───── LIBRARY ─────
 


### PR DESCRIPTION
This fix issue if upper project use `find_package(Qt5)` and Qt6 is also installed. This require at least Qt5.15 to use versionless `Qt` target namespace